### PR TITLE
update crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `embedded-hal` to v1.0
+- Bumped Rust edition to 2021
+- Rename `temp` field in `Measurement` to `temp_raw` to make it explicit this is not an actual valid temperature
+- Rename `temp` getter to `temp_raw` and add `temp_celcius` getter
+
+### Added
+
+- Add `temp_celcius` getter for `Measurement`
+- Add optional `defmt` support
+
+## [v0.3.0] - 2020-09-06
+
 ## [v0.2.0] - 2018-05-12
 
 ### Changed
@@ -34,7 +48,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 Initial release
 
-[Unreleased]: https://github.com/japaric/l3gd20/compare/v0.2.0...HEAD
-[v0.2.0]: https://github.com/japaric/l3gd20/compare/v0.1.2...v0.2.0
-[v0.1.2]: https://github.com/japaric/l3gd20/compare/v0.1.1...v0.1.2
-[v0.1.1]: https://github.com/japaric/l3gd20/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/tstellanova/l3gd20/compare/v0.3.0...HEAD
+[v0.3.0]: https://github.com/tstellanova/l3gd20/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/tstellanova/l3gd20/compare/v0.1.2...v0.2.0
+[v0.1.2]: https://github.com/tstellanova/l3gd20/compare/v0.1.1...v0.1.2
+[v0.1.1]: https://github.com/tstellanova/l3gd20/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 authors = ["Jorge Aparicio <jorge@japaric.io>"]
-edition = "2018"
+edition = "2021"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "A platform agnostic driver to interface the L3GD20 (gyroscope)"
 documentation = "https://docs.rs/l3gd20"
-keywords = ["embedded-hal-driver", "gyroscope", "MEMS"]
+keywords = ["embedded-hal-driver", "gyroscope", "MEMS", "l3gd20"]
 license = "MIT OR Apache-2.0"
 name = "l3gd20"
-repository = "https://github.com/japaric/l3gd20"
-version = "0.3.0"
+repository = "https://github.com/tstellanova/l3gd20"
+version = "0.4.0"
 
 [dependencies]
-embedded-hal = "0.2.4"
+embedded-hal = "1"
+defmt = { version = "0.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `l3gd20`
 
-> A platform agnostic driver to interface with the L3GD20 (gyroscope)
+> A platform agnostic driver to interface with the L3GD20 and L3GD20H (gyroscope)
 
 ## What works
 
@@ -9,8 +9,8 @@
 
 ## TODO
 
+- [ ] I2C support
 - [ ] Make sure this works with the `spidev` crate (i.e. with the Raspberry Pi)
-- [ ] Configuration. e.g. selecting the gyroscope sensing range / sensitivity.
 - [ ] How to make the API compatible with device specific features like DMA and interrupts?
 - ???
 


### PR DESCRIPTION
- Bump version to v0.4
- Bump `embedded-hal` to v1
- Some clippy fixes
- Bump Rust edition to 2021
- Rename `temp` field in `Measurement` to `temp_raw` to make it explicit this is not an actual valid temperature
- Rename `temp` getter to `temp_raw` and add `temp_celcius` getter
- Add `temp_celcius` getter for `Measurement`
- Add optional `defmt` support